### PR TITLE
Fix: gitignore에 yml파일 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -18,6 +18,9 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+application.yml
+application-local.yml
+application-server.yml
 .idea
 *.iws
 *.iml


### PR DESCRIPTION
gitignore에 yml파일을 추가했습니다.
application.yml
application-local.yml
application-server.yml
위의 세 가지를 추가했습니다.

개인 local설정 시, application-local.yml 파일을 만들어 사용하시면 되시며, 
intelliJ 구성편집에서 프로파일 설정 하시고 사용하시면 됩니다.

--spring.pofiles.active=프로파일명
ex) --spring.pofiles.active=local
ex) --spring.pofiles.active=server

참고용으로 제 개인 설정은 아래와 같습니다.

spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: jdbc:mysql://localhost:3306/<스키마_명>
    username: DB_명
    password: DB_비밀번호
  jpa:
    hibernate:
      ddl-auto: create
    defer-datasource-initialization: true
  sql:
    init:
      data-locations: classpath:static/db/data.sql
      mode: always

decorator:
  datasource:
    p6spy:
      enable-logging: true

file:
  img: /Users/hipo/Desktop/Img/

iam:
  access-key: local
  secret-key: local
  region: local

cloud:
  aws:
    region:
      static: ap-northeast-2
    stack:
      auto: false

mod: local