### PR TITLE
[BE] application.yml h2 수정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,14 +8,14 @@ server:
       force: true
 
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2
-  datasource:
-    url: jdbc:h2:mem:test
-  #  profiles:
-  #    active: local   // 로컬 프로파일 사용을 위한 설정
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2
+#  datasource:
+#    url: jdbc:h2:mem:test
+  profiles:
+    active: local   # 로컬 프로파일 사용을 위한 설정
   jpa:
     hibernate:
       ddl-auto: update

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,20 +8,27 @@ server:
       force: true
 
 spring:
-  profiles:
-    active: local
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  datasource:
+    url: jdbc:h2:mem:test
+  #  profiles:
+  #    active: local   // 로컬 프로파일 사용을 위한 설정
   jpa:
     hibernate:
-      profiles: # local
+      ddl-auto: update
+      profiles:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
     properties:
       hibernate:
         default_batch_fetch_size: 100
   data:
     web:
       pageable:
-        default-page-size: 10
         one-indexed-parameters: true
 jwt:
   key:


### PR DESCRIPTION
기존 application.yml 세팅으로 h2가 활성화 되지 않아 수정했습니다.

1. application-local.yml를 따로 만들지 않고 default값으로 사용하실 경우, 이번 PR내용 그대로 pull 하셔서 사용하시면 됩니다.
: h2 사용 방식

2. application-local.yml를 따로 만들어서 MySQL을 사용하실 경우, 다음과 같이 사용하시면 됩니다.
 1) build.gradle에서 h2를 비활성화 하고, mysql을 활성화 합니다.
![image](https://user-images.githubusercontent.com/94734089/201460812-a9c694c8-71f6-4bc4-b926-e2aae93d7c82.png)
 2) application.yml에서 h2관련 설정을 비활성화 합니다. 그리고 application-local.yml사용 설정을 활성화 합니다.
     그림과 같이 application.yml에서 local로 활성화 설정을 해주셔도 되고, 유어클래스처럼 구성 편집에서 해주셔도 됩니다.
![image](https://user-images.githubusercontent.com/94734089/201460934-12e2ccfb-8995-417b-8a32-61ff7929ece7.png)
![image](https://user-images.githubusercontent.com/94734089/201460973-a35a3a6c-7606-4f5b-bf75-40b0e4b7a9b3.png)

3. application-local.yml 에서 MySQL을 설정하여 사용하시면 됩니다. 다음은 참고용 제 local.yml설정입니다.
![image](https://user-images.githubusercontent.com/94734089/201461037-d6e71219-84ad-47ed-817b-c268696ff95e.png)

