### PR TITLE
[BE] Battery 기본 CRUD API

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-//	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -47,6 +47,8 @@ dependencies {
 	testImplementation 'com.h2database:h2:1.4.199'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 tasks.named('test') {
 	outputs.dir snippetsDir

--- a/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
+++ b/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
@@ -1,0 +1,79 @@
+package backend.domain.battery.controller;
+
+import backend.domain.battery.dto.BatteryDto;
+import backend.domain.battery.entity.Battery;
+import backend.domain.battery.mapper.BatteryMapper;
+import backend.domain.battery.service.BatteryService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@RestController
+@RequestMapping("/batteries")
+@Validated
+@Slf4j
+public class BatteryController {
+    private final BatteryService batteryService;
+    private final BatteryMapper mapper;
+
+    public BatteryController(BatteryService batteryService, BatteryMapper mapper){
+        this.batteryService = batteryService;
+        this.mapper = mapper;
+    }
+
+    // 배터리 정보 등록
+    @PostMapping
+    public ResponseEntity postBattery(@Valid @RequestBody BatteryDto.Post requestBody){
+        Battery battery = mapper.batteryPostDtoToBattery(requestBody);
+        Battery createBattery = batteryService.createBattery(battery);
+        BatteryDto.Response response = mapper.batteryToBatteryResponse(createBattery);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 해당 ID 배터리 수정
+    @PatchMapping("/{batteryId}")
+    public ResponseEntity patchBattery(@PathVariable("batteryId") @Positive long batteryId,
+                                       @Valid @RequestBody BatteryDto.Patch requestBody){
+        requestBody.setBatteryId((batteryId));
+        Battery battery = mapper.batteryPatchDtoToBattery(requestBody);
+        Battery updateBattery = batteryService.updateBattery(battery);
+        BatteryDto.Response response = mapper.batteryToBatteryResponse(updateBattery);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 해당 ID 배터리 조회
+    @GetMapping("/{batteryId}")
+    public ResponseEntity getBattery(@PathVariable("batteryId") @Positive long batteryId){
+        Battery battery = batteryService.findBattery(batteryId);
+        BatteryDto.Response response = mapper.batteryToBatteryResponse(battery);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 배터리 전체 조회
+    @GetMapping
+    public ResponseEntity getBatteries(@Positive @RequestParam int page,
+                                       @Positive @RequestParam int size){
+        Page<Battery> batteries = batteryService.findBatteries(page - 1, size);
+        List<Battery> batteryList = batteries.getContent();
+        List<BatteryDto.Response> response = mapper.batteryToBatteryResponse(batteryList);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    //해당 ID 배터리 삭제
+    @DeleteMapping("/{batteryId}")
+    public ResponseEntity deleteBattery(@PathVariable("batteryId") @Positive long batteryId){
+        batteryService.deleteBattery(batteryId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
+++ b/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
@@ -1,0 +1,53 @@
+package backend.domain.battery.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public class BatteryDto {
+    @Getter
+    @Setter
+    public static class Post{
+        @NotBlank(message = "type을 입력해주세요.")
+        private String type;
+
+        @NotNull(message = "상태를 설정해주세요.")
+        private boolean status;
+
+        @NotNull(message = "가격을 입력해주세요.")
+        private int price;
+
+        @URL
+        private String photoURL;
+
+        @NotNull(message ="ZONE ID 를 입력해주세요.")
+        private long zoneId;
+    }
+
+    @Getter
+    @Setter
+    public static class Patch{
+        private long batteryId;
+        private boolean status;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Response{
+        private long batteryId;
+        private String type;
+        private boolean status;
+        private int price;
+        private String photoURL;
+        private long zoneId;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+    }
+}

--- a/backend/src/main/java/backend/domain/battery/entity/Battery.java
+++ b/backend/src/main/java/backend/domain/battery/entity/Battery.java
@@ -1,0 +1,43 @@
+package backend.domain.battery.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+public class Battery {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long batteryId;
+
+    @Column
+    private String type;
+
+    @Column
+    private boolean status;
+
+    @Column
+    private int price;
+
+    //@URL
+    @Column
+    private String photoURL;
+
+//    @ManyToOne
+//    @JoinColumn(name = "ZONE_ID")
+//    private Zone zone;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false, name = "LAST_MODIFIED_AT")
+    private LocalDateTime modifiedAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/backend/domain/battery/mapper/BatteryMapper.java
+++ b/backend/src/main/java/backend/domain/battery/mapper/BatteryMapper.java
@@ -1,0 +1,15 @@
+package backend.domain.battery.mapper;
+
+import backend.domain.battery.dto.BatteryDto;
+import backend.domain.battery.entity.Battery;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BatteryMapper {
+    Battery batteryPostDtoToBattery(BatteryDto.Post requestBody);
+    Battery batteryPatchDtoToBattery(BatteryDto.Patch requestBody);
+    BatteryDto.Response batteryToBatteryResponse(Battery battery);
+    List<BatteryDto.Response> batteryToBatteryResponse(List<Battery> batteries);
+}

--- a/backend/src/main/java/backend/domain/battery/repository/BatteryRepository.java
+++ b/backend/src/main/java/backend/domain/battery/repository/BatteryRepository.java
@@ -1,0 +1,7 @@
+package backend.domain.battery.repository;
+
+import backend.domain.battery.entity.Battery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BatteryRepository extends JpaRepository<Battery,Long> {
+}

--- a/backend/src/main/java/backend/domain/battery/service/BatteryService.java
+++ b/backend/src/main/java/backend/domain/battery/service/BatteryService.java
@@ -1,0 +1,64 @@
+package backend.domain.battery.service;
+
+import backend.domain.battery.entity.Battery;
+import backend.domain.battery.repository.BatteryRepository;
+import backend.global.exception.dto.BusinessLoginException;
+import backend.global.exception.exceptionCode.ExceptionCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class BatteryService {
+    private final BatteryRepository batteryRepository;
+
+    public BatteryService(BatteryRepository batteryRepository){
+        this.batteryRepository = batteryRepository;
+    }
+
+    // 배터리 등록
+    public Battery createBattery(Battery battery){
+        return batteryRepository.save(battery);
+    }
+
+    // 배터리 수정
+    public Battery updateBattery(Battery battery){
+        Battery findBattery = findVerifiedBattery(battery.getBatteryId());
+        Optional.of(battery.isStatus()).ifPresent(status -> findBattery.setStatus(status));
+        findBattery.setModifiedAt(LocalDateTime.now());
+
+        return batteryRepository.save(findBattery);
+    }
+
+    // 해당 ID 배터리 조회
+    public Battery findBattery(long batteryId){
+        Battery findBattery = findVerifiedBattery(batteryId);
+        findBattery.setCreatedAt(findBattery.getCreatedAt());
+
+        return findBattery;
+    }
+
+    // 배터리 전체 조회
+    public Page<Battery> findBatteries(int page, int size){
+        return batteryRepository.findAll(PageRequest.of(page, size, Sort.by("batteryId").descending()));
+    }
+
+    // 해당 ID 배터리 삭제
+    public void deleteBattery(long batteryId){
+        Battery findBattery = findVerifiedBattery(batteryId);
+        batteryRepository.delete(findBattery);
+    }
+
+
+    // 해당 ID의 배터리가 존재하는지 검증
+    private Battery findVerifiedBattery(long batteryId) {
+        Optional<Battery> optionalBattery = batteryRepository.findById(batteryId);
+        Battery findBattery = optionalBattery.orElseThrow(() ->
+                new BusinessLoginException(ExceptionCode.BATTERY_NOT_FOUND));
+        return findBattery;
+    }
+}

--- a/backend/src/main/java/backend/global/exception/exceptionCode/ExceptionCode.java
+++ b/backend/src/main/java/backend/global/exception/exceptionCode/ExceptionCode.java
@@ -15,7 +15,8 @@ public enum ExceptionCode {
     ACCESS_TOKEN_EXPIRATION(401, "재 로그인이 필요합니다."),
     LOGIN_FAILURE(401, "아이디 혹은 비밀번호가 옳지 않습니다."),
 
-    ILLEGAL_FILENAME(400, "잘못된 형식의 파일명입니다.");
+    ILLEGAL_FILENAME(400, "잘못된 형식의 파일명입니다."),
+    BATTERY_NOT_FOUND(400, "해당하는 ID의 배터리가 존재하지 않습니다.");
 
 
     @Getter


### PR DESCRIPTION
## 구현 내용
Battery 기본 API를 구현하였습니다.
DTO 패키지를 내부에 Post, Patch, ResponseDto를 생성하였습니다.
Battery를 생성하고 해당 ID의 Battery를 조회, 수정, 삭제할 수 있습니다.
모든 Battery를 page와 size 파라미터와 함께 조회할 수 있습니다.

## 전달할 내용
buildGradle에 mapstruct 의존성을 추가하였습니다.
ExceptionCode에 'BATTERY_NOT_FOUND'를 추가하였습니다.