### PR TITLE
[BE] Member API 수정

### DIFF
--- a/backend/src/main/java/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/domain/member/controller/MemberController.java
@@ -52,8 +52,9 @@ public class MemberController {
     public ResponseEntity<MemberDto.Response> patchMember (@PathVariable("member-id") Long memberId,
                                                                       @RequestBody MemberDto.Patch dto) {
         Member member = mapper.memberDtoPatchToMember(dto);
+        member.setMemberId(memberId);
         Member modifiedMember = service.patchMember(member);
-        MemberDto.Response response = mapper.memberToMemberDtoResponse(modifiedMember);
+        MemberDto.Response response = new MemberDto.Response(modifiedMember);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/backend/src/main/java/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/domain/member/controller/MemberController.java
@@ -29,7 +29,6 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<MemberDto.Response> postMember(@Valid @RequestBody MemberDto.Post dto) {
 
-
         Member member = mapper.memberDtoPostToMember(dto);  // 식별자 값이 DB저장까지는 나오지 않아 mapper가 식별자 값을 못잡는 주의문구가 뜹니다. 사용에는 지장이 없으니 주의문구는 무시하셔도 좋습니다.
         Member createdMember = service.createMember(member);
 //        MemberDto.Response response = mapper.memberToMemberDtoResponse(createdMember); // 매퍼에서 일부 값을 받지 못해 null값이 반환되어 우선 생성자를 사용한 변환방법으로 사용했습니다
@@ -52,7 +51,7 @@ public class MemberController {
     public ResponseEntity<MemberDto.Response> patchMember (@PathVariable("member-id") Long memberId,
                                                                       @RequestBody MemberDto.Patch dto) {
         Member member = mapper.memberDtoPatchToMember(dto);
-        member.setMemberId(memberId);
+        member.setId(memberId);
         Member modifiedMember = service.patchMember(member);
         MemberDto.Response response = new MemberDto.Response(modifiedMember);
 

--- a/backend/src/main/java/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/domain/member/controller/MemberController.java
@@ -5,14 +5,16 @@ import backend.domain.member.dto.MemberDto;
 import backend.domain.member.entity.Member;
 import backend.domain.member.mapper.MemberMapper;
 import backend.domain.member.service.MemberService;
+import backend.global.dto.PageInfoDto;
 import backend.global.dto.SingleResDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
@@ -25,32 +27,56 @@ public class MemberController {
     private final MemberService service;
 
     @PostMapping
-    public ResponseEntity postMember(@Valid @RequestBody MemberDto.Post dto) {
+    public ResponseEntity<MemberDto.Response> postMember(@Valid @RequestBody MemberDto.Post dto) {
 
 
-        Member member = mapper.memberDtoPostToMember(dto);
+        Member member = mapper.memberDtoPostToMember(dto);  // 식별자 값이 DB저장까지는 나오지 않아 mapper가 식별자 값을 못잡는 주의문구가 뜹니다. 사용에는 지장이 없으니 주의문구는 무시하셔도 좋습니다.
         Member createdMember = service.createMember(member);
-        MemberDto.Response response = mapper.memberToMemberDtoResponse(createdMember);
-        SingleResDto<MemberDto.Response> singleResDto = new SingleResDto<>(response);
+//        MemberDto.Response response = mapper.memberToMemberDtoResponse(createdMember); // 매퍼에서 일부 값을 받지 못해 null값이 반환되어 우선 생성자를 사용한 변환방법으로 사용했습니다
+        MemberDto.Response response = new MemberDto.Response(createdMember);
 
-        return new ResponseEntity(singleResDto, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @GetMapping("/{member-id}")
-    public ResponseEntity getMember(@Positive @PathVariable("member-id") Long memberId) {
+    public ResponseEntity<MemberDto.Response> getMember(@Positive @PathVariable("member-id") Long memberId) {
 
         Member findMember = service.findMember(memberId);
-        MemberDto.Response response = mapper.memberToMemberDtoResponse(findMember);
-        SingleResDto<MemberDto.Response> singleResDto = new SingleResDto<>(response);
+//        MemberDto.Response response = mapper.memberToMemberDtoResponse(findMember);  // 매퍼에서 일부 값을 받지 못해 null값이 반환되어 우선 생성자를 사용한 변환방법으로 사용했습니다
+        MemberDto.Response response = new MemberDto.Response(findMember);
 
-        return new ResponseEntity(singleResDto, HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PostMapping("/logout")
-    public ResponseEntity logOut(HttpServletRequest request) {
-        System.out.println("로그아웃");
-        service.outMember(request);
+    @PatchMapping("/{member-id}")
+    public ResponseEntity<MemberDto.Response> patchMember (@PathVariable("member-id") Long memberId,
+                                                                      @RequestBody MemberDto.Patch dto) {
+        Member member = mapper.memberDtoPatchToMember(dto);
+        Member modifiedMember = service.patchMember(member);
+        MemberDto.Response response = mapper.memberToMemberDtoResponse(modifiedMember);
 
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @DeleteMapping("/{member-id}")
+    public ResponseEntity<SingleResDto<String>> deleteMember (@PathVariable("member-id") Long memberId) {
+        service.deleteMember(memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageInfoDto> getMembers (Pageable pageable) {
+        Page<Member> page = service.findMembers(pageable);
+
+        return new ResponseEntity<>(new PageInfoDto(page), HttpStatus.OK);
+    }
+
+//    @PostMapping("/logout")                   // 현재 시큐리티 미적용 상태이므로 주석처리 해두었습니다.
+//    public ResponseEntity logOut(HttpServletRequest request) {
+//        System.out.println("로그아웃");
+//        service.outMember(request);
+//
+//        return new ResponseEntity(HttpStatus.OK);
+//    }
 }

--- a/backend/src/main/java/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/backend/domain/member/dto/MemberDto.java
@@ -8,13 +8,14 @@ import org.hibernate.validator.constraints.URL;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import java.time.LocalDateTime;
 
 
 public class MemberDto {
 
     @NoArgsConstructor @AllArgsConstructor
     @Getter @Setter
-    public static class Post extends BaseTime {
+    public static class Post {
 
         @NotBlank @Email
         private String email;
@@ -37,7 +38,7 @@ public class MemberDto {
 
     @NoArgsConstructor @AllArgsConstructor
     @Getter @Setter
-    public static class Patch extends BaseTime {
+    public static class Patch {
 
         //정규식 필요
         @NotBlank @Pattern(regexp = "^[가-힣a-zA-Z]*$")
@@ -69,6 +70,10 @@ public class MemberDto {
 
         private String photoUrl;
 
+        private LocalDateTime createdAt;
+
+        private LocalDateTime modifiedAt;
+
         public Response (Member member) {
             this.memberId = member.getMemberId();
             this.email = member.getEmail();
@@ -76,8 +81,8 @@ public class MemberDto {
             this.phone = member.getPhone();
             this.address = member.getAddress();
             this.photoUrl = member.getPhotoURL();
-            member.getCreatedAt();
-            member.getModifiedAt();
+            this.createdAt = member.getCreatedAt();
+            this.modifiedAt = member.getModifiedAt();
         }
 
     }

--- a/backend/src/main/java/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/backend/domain/member/dto/MemberDto.java
@@ -75,7 +75,7 @@ public class MemberDto {
         private LocalDateTime modifiedAt;
 
         public Response (Member member) {
-            this.memberId = member.getMemberId();
+            this.memberId = member.getId();
             this.email = member.getEmail();
             this.nickname = member.getNickname();
             this.phone = member.getPhone();
@@ -84,6 +84,5 @@ public class MemberDto {
             this.createdAt = member.getCreatedAt();
             this.modifiedAt = member.getModifiedAt();
         }
-
     }
 }

--- a/backend/src/main/java/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/backend/domain/member/dto/MemberDto.java
@@ -1,6 +1,9 @@
 package backend.domain.member.dto;
 
+import backend.domain.member.entity.Member;
+import backend.global.auditing.BaseTime;
 import lombok.*;
+import org.hibernate.validator.constraints.URL;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -8,20 +11,15 @@ import javax.validation.constraints.Pattern;
 
 
 public class MemberDto {
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Getter
-    @Setter
-    public static class Post{
 
-        @NotBlank
-        @Email
+    @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter
+    public static class Post extends BaseTime {
+
+        @NotBlank @Email
         private String email;
 
-
-        @NotBlank
-        @Pattern(regexp = "^[가-힣a-zA-Z]*$")
+        @NotBlank @Pattern(regexp = "^[가-힣a-zA-Z]*$")
         private String nickname;
 
         @NotBlank
@@ -31,46 +29,56 @@ public class MemberDto {
         private String phone;
 
         @NotBlank
-        private Long carId;
-
         private String address;
 
+        @URL
         private String photoURL;
     }
 
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Getter
-    @Setter
-    public static class Patch{
+    @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter
+    public static class Patch extends BaseTime {
 
         //정규식 필요
-        @Pattern(regexp = "^[가-힣a-zA-Z]*$")
+        @NotBlank @Pattern(regexp = "^[가-힣a-zA-Z]*$")
         private String nickname;
 
-        private String carId;
-
+        @NotBlank
         private String phone;
 
+        @NotBlank
         private String address;
 
+        @URL
         private String photoURL;
     }
 
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Getter
-    @Setter
+    @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter
     public static class Response{
 
-        private Long userId;
+        private Long memberId;
 
         private String email;
 
         private String nickname;
 
+        private String phone;
+
+        private String address;
+
         private String photoUrl;
+
+        public Response (Member member) {
+            this.memberId = member.getMemberId();
+            this.email = member.getEmail();
+            this.nickname = member.getNickname();
+            this.phone = member.getPhone();
+            this.address = member.getAddress();
+            this.photoUrl = member.getPhotoURL();
+            member.getCreatedAt();
+            member.getModifiedAt();
+        }
 
     }
 }

--- a/backend/src/main/java/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/backend/domain/member/entity/Member.java
@@ -2,17 +2,23 @@ package backend.domain.member.entity;
 
 import backend.global.auditing.BaseTime;
 import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 //import org.springframework.security.core.GrantedAuthority;
 //import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import javax.persistence.*;
 
-@AllArgsConstructor @NoArgsConstructor
-@Entity @Setter @Getter @Builder
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity @Builder @Getter @Setter
 public class Member extends BaseTime {
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id @Column(name = "memberId")
-    private Long memberId;
+    @GeneratedValue
+    @Id
+    private Long id;
 
     @Column(nullable = false)
     private String password;
@@ -42,34 +48,34 @@ public class Member extends BaseTime {
 //        return authorities;
 //    }
 
-    public String getPassword() {
-        return this.getPassword();
-    }
-
-
-    public String getUsername() {
-        return this.getEmail();
-    }
-
-
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-
-    public boolean isEnabled() {
-        return true;
-    }
+//    public String getPassword() {
+//        return this.getPassword();
+//    }
+//
+//
+//    public String getUsername() {
+//        return this.getEmail();
+//    }
+//
+//
+//    public boolean isAccountNonExpired() {
+//        return true;
+//    }
+//
+//
+//    public boolean isAccountNonLocked() {
+//        return true;
+//    }
+//
+//
+//    public boolean isCredentialsNonExpired() {
+//        return true;
+//    }
+//
+//
+//    public boolean isEnabled() {
+//        return true;
+//    }
 
 }
 

--- a/backend/src/main/java/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/backend/domain/member/entity/Member.java
@@ -1,27 +1,17 @@
 package backend.domain.member.entity;
 
+import backend.global.auditing.BaseTime;
 import lombok.*;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+//import org.springframework.security.core.GrantedAuthority;
+//import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import javax.persistence.*;
-import javax.transaction.Transactional;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
-@Builder
-@Transactional
-@AllArgsConstructor
-@NoArgsConstructor
-@Setter
-@Getter
-@Entity
-
-public class Member {
+@AllArgsConstructor @NoArgsConstructor
+@Entity @Setter @Getter @Builder
+public class Member extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id
+    @Id @Column(name = "memberId")
     private Long memberId;
 
     @Column(nullable = false)
@@ -36,21 +26,21 @@ public class Member {
     @Column(nullable = false)
     private String phone;
 
+    @Column(nullable = false)
+    private String address;
 
-//
-//    @Column(nullable = false)
-//    @OneToMany
-//    @JoinColumn(name = "CAR_Id")
-//    private Car car;
-
-@ElementCollection(fetch = FetchType.EAGER)
-List<String> roles = new ArrayList<>();
+    @Column(nullable = false)
+    private String photoURL;
 
 
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        List<GrantedAuthority> authorities = this.getRoles().stream().map(strAuth -> new SimpleGrantedAuthority("ROLE_" + strAuth)).collect(Collectors.toList());
-        return authorities;
-    }
+//    @ElementCollection(fetch = FetchType.EAGER)     현재 시큐리티 미적용 상태이므로 주석처리 해두었습니다
+//    List<String> roles = new ArrayList<>();
+
+
+//    public Collection<? extends GrantedAuthority> getAuthorities() {   현재 시큐리티 미적용 상태이므로 주석처리 해두었습니다
+//        List<GrantedAuthority> authorities = this.getRoles().stream().map(strAuth -> new SimpleGrantedAuthority("ROLE_" + strAuth)).collect(Collectors.toList());
+//        return authorities;
+//    }
 
     public String getPassword() {
         return this.getPassword();

--- a/backend/src/main/java/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/backend/domain/member/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package backend.domain.member.repository;
 
 import backend.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,10 +11,16 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
 
-    @Query(value = "select m from Member m where m.email = :email or m.nickname = :name")
+    @Query(value = "select m from Member m where m.email = :email or m.nickname = :name order by m.createdAt desc")
     Optional<Member> findMemberByEmailOrNickname(@Param("email") String email, @Param("name") String name);
 
-    @Query(value = "select m from Member m where m.email = :email")
+    @Query(value = "select m from Member m where m.email = :email order by m.createdAt desc")
     Optional<Member> findByMemberEmail(String email);
 
+    // 나눠서 처리를 위해 작성해주신 코드와 같은 방식으로 메소드를 추가했습니다.
+    @Query(value = "select m from Member m where m.nickname = :nickname order by m.createdAt desc")
+    Optional<Member> findByMemberNickname(String nickname);
+
+    @Query(value = "select m from Member m order by m.createdAt desc")
+    Page<Member>findAllByOrderByCreatedAtDesc (Pageable pageable);
 }

--- a/backend/src/main/java/backend/domain/member/service/MemberDetailsService.java
+++ b/backend/src/main/java/backend/domain/member/service/MemberDetailsService.java
@@ -1,37 +1,38 @@
-package backend.domain.member.service;
-
-import backend.domain.member.entity.Member;
-import backend.domain.member.repository.MemberRepository;
-import backend.global.exception.exceptionCode.BusinessException;
-import backend.global.exception.exceptionCode.ExceptionCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Component;
-
-@RequiredArgsConstructor
-@Component
-public class MemberDetailsService implements UserDetailsService {
-
-    private final MemberRepository repository;
-
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-        Member findMember = verifyExistsMember(username);
-
-        return (UserDetails) findMember;
-    }
-
-
-
-    private Member verifyExistsMember(String email) {
-
-        Member findMember = repository.findByMemberEmail(email).orElseThrow(() -> {
-            throw new BusinessException(ExceptionCode.MEMBER_NOT_EXISTS);
-        });
-
-        return findMember;
-    }
-}
+//package backend.domain.member.service;
+//
+//import backend.domain.member.entity.Member;
+//import backend.domain.member.repository.MemberRepository;
+//import backend.global.exception.exceptionCode.BusinessException;
+//import backend.global.exception.exceptionCode.ExceptionCode;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.core.userdetails.UserDetails;
+//import org.springframework.security.core.userdetails.UserDetailsService;
+//import org.springframework.security.core.userdetails.UsernameNotFoundException;
+//import org.springframework.stereotype.Component;
+//
+//@RequiredArgsConstructor
+//@Component
+//public class MemberDetailsService implements UserDetailsService {
+//
+//    private final MemberRepository repository;
+//
+//    @Override
+//    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+//
+//        Member findMember = verifyExistsMember(username);
+//
+//        return (UserDetails) findMember;
+//    }
+//
+//
+//
+//    private Member verifyExistsMember(String email) {
+//
+//        Member findMember = repository.findByMemberEmail(email).orElseThrow(() -> {
+//            throw new BusinessException(ExceptionCode.MEMBER_NOT_EXISTS);
+//        });
+//
+//        return findMember;
+//    }
+//}
+// 현재 시큐리티 미적용으로 주석처리 했습니다.

--- a/backend/src/main/java/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/backend/domain/member/service/MemberService.java
@@ -2,91 +2,116 @@ package backend.domain.member.service;
 
 import backend.domain.member.entity.Member;
 import backend.domain.member.repository.MemberRepository;
-import backend.domain.member.utils.CustomAuthorityUtil;
-import backend.global.exception.exceptionCode.BusinessException;
+//import backend.domain.member.utils.CustomAuthorityUtil;
+import backend.global.exception.dto.BusinessLogicException;
+//import backend.global.exception.exceptionCode.BusinessException;
 import backend.global.exception.exceptionCode.ExceptionCode;
-import backend.global.security.jwt.JwtTokenizer;
+//import backend.global.security.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.security.crypto.password.PasswordEncoder;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.core.ValueOperations;
+//import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-@Transactional
-@RequiredArgsConstructor
-@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor @Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final CustomAuthorityUtil customAuthorityUtil;
-    private final JwtTokenizer jwtTokenizer;
-    private final RedisTemplate redisTemplate;
+//    private final PasswordEncoder passwordEncoder;          // 현재 시큐리티 미적용 상태이므로 주석처리해두었습니다.
+//    private final CustomAuthorityUtil customAuthorityUtil;
+//    private final JwtTokenizer jwtTokenizer;
+//    private final RedisTemplate redisTemplate;
 
-
+    @Transactional
     public Member createMember(Member member) {
-        verifyNotExistsMember(member.getEmail(), member.getNickname());
-        member.setPassword(passwordEncoder.encode(member.getPassword()));
-        member.setRoles(customAuthorityUtil.getRole());
+        verifyNotExistsMember(member);
+//        member.setPassword(passwordEncoder.encode(member.getPassword()));  // 현재 시큐리티 미적용으로 주석처리 해두었습니다.
+//        member.setRoles(customAuthorityUtil.getRole());
+        member.setCreatedAt(LocalDateTime.now());
+        member.setModifiedAt(LocalDateTime.now());
         Member savedMember = memberRepository.save(member);
         return savedMember;
 
     }
 
-    public Member removeMember(Long memberId) {
+    @Transactional
+    public Member patchMember(Member member) {
+        Member verifiedMember = verifyExistsMember(member.getMemberId());
+        Optional.ofNullable(member.getNickname()).ifPresent(verifiedMember::setNickname);
+        Optional.ofNullable(member.getPhone()).ifPresent(verifiedMember::setPhone);
+        Optional.ofNullable(member.getAddress()).ifPresent(verifiedMember::setAddress);
+        Optional.ofNullable(member.getPhotoURL()).ifPresent(verifiedMember::setPhotoURL);
+        verifiedMember.setModifiedAt(LocalDateTime.now());
+
+        return memberRepository.save(verifiedMember);
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
         Member deletingMember = verifyExistsMember(memberId);
-        Member deletedMember = memberRepository.save(deletingMember);
-        return deletedMember;
+        memberRepository.delete(deletingMember);
     }
 
     public Member findMember(Long memberId) {
-
         Member findMember = verifyExistsMember(memberId);
+
         return findMember;
     }
 
-    public List<Member> findMembers() {
+    public Page<Member> findMembers(Pageable pageable) {
+        Page<Member> allMemberList = memberRepository.findAllByOrderByCreatedAtDesc(pageable);
 
-        List<Member> allMemberList = memberRepository.findAll();
         return allMemberList;
     }
 
-    public void outMember(HttpServletRequest request) {
-
-        String authentication = request.getHeader("Authorization");
-        String jws = authentication.replace("bearer", "");
-        registerJws(jws);
-    }
+//    public void outMember(HttpServletRequest request) {      현재 시큐리티 미적용으로 주석처리 했습니다.
+//
+//        String authentication = request.getHeader("Authorization");
+//        String jws = authentication.replace("bearer", "");
+//        registerJws(jws);
+//    }
 
 
 
 //
 //
-    private void verifyNotExistsMember(String email, String name) {
+    private void verifyNotExistsMember(Member member) {
+        Optional<Member> optionalEmail = memberRepository.findByMemberEmail(member.getEmail());
+        if (optionalEmail.isPresent()) {
+            throw new BusinessLogicException(ExceptionCode.EMAIL_EXIST);
+        }
 
-        memberRepository.findMemberByEmailOrNickname(email, name).ifPresent(
-                findMember -> {throw new BusinessException(ExceptionCode.ACCOUNT_EXIST);});
+        Optional<Member> optionalNickname = memberRepository.findByMemberNickname(member.getNickname());
+        if (optionalNickname.isPresent()) {
+            throw new BusinessLogicException(ExceptionCode.NICKNAME_EXIST);
+        }
 
     }
 
     private Member verifyExistsMember(Long memberId) {
 
         return memberRepository.findById(memberId).orElseThrow(()->
-        {throw new BusinessException(ExceptionCode.MEMBER_NOT_EXISTS);});
+        {throw new BusinessLogicException(ExceptionCode.NOT_FOUND_MEMBER);});
 
     }
 
-    private void registerJws(String jws) {
-        Map<String, Object> verifyJws = jwtTokenizer.verifyJws(jws);
-        ValueOperations valueOperations = redisTemplate.opsForValue();
-        String username = (String)verifyJws.get("username");
-        valueOperations.set("logout_"+jws,username, Duration.ofMinutes(jwtTokenizer.getAccessTokenExpirationMinutes()));
-    }
+//    private void registerJws(String jws) {                           현재 시큐리티 미적용으로 주석처리 했습니다.
+//        Map<String, Object> verifyJws = jwtTokenizer.verifyJws(jws);
+//        ValueOperations valueOperations = redisTemplate.opsForValue();
+//        String username = (String)verifyJws.get("username");
+//        valueOperations.set("logout_"+jws,username, Duration.ofMinutes(jwtTokenizer.getAccessTokenExpirationMinutes()));
+//    }
 
 }

--- a/backend/src/main/java/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/backend/domain/member/service/MemberService.java
@@ -14,14 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Transactional(readOnly = true)
@@ -48,7 +42,7 @@ public class MemberService {
 
     @Transactional
     public Member patchMember(Member member) {
-        Member verifiedMember = verifyExistsMember(member.getMemberId());
+        Member verifiedMember = verifyExistsMember(member.getId());
         Optional.ofNullable(member.getNickname()).ifPresent(verifiedMember::setNickname);
         Optional.ofNullable(member.getPhone()).ifPresent(verifiedMember::setPhone);
         Optional.ofNullable(member.getAddress()).ifPresent(verifiedMember::setAddress);
@@ -65,15 +59,13 @@ public class MemberService {
     }
 
     public Member findMember(Long memberId) {
-        Member findMember = verifyExistsMember(memberId);
 
-        return findMember;
+        return verifyExistsMember(memberId);
     }
 
     public Page<Member> findMembers(Pageable pageable) {
-        Page<Member> allMemberList = memberRepository.findAllByOrderByCreatedAtDesc(pageable);
 
-        return allMemberList;
+        return memberRepository.findAllByOrderByCreatedAtDesc(pageable);
     }
 
 //    public void outMember(HttpServletRequest request) {      현재 시큐리티 미적용으로 주석처리 했습니다.

--- a/backend/src/main/java/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/backend/domain/order/controller/OrderController.java
@@ -45,7 +45,7 @@ public class OrderController {
     @DeleteMapping("/{orderId}")
     public ResponseEntity<SingleResDto<String>> deleteOrder (@PathVariable Long orderId) {
         orderService.deleteOrder(orderId);
-        return new ResponseEntity<>(new SingleResDto<>("success delete"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
     }
 
 

--- a/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
@@ -5,6 +5,7 @@ import backend.domain.payment.dto.PayPostReqDto;
 import backend.domain.payment.dto.PayResDto;
 import backend.domain.payment.entity.Payment;
 import backend.domain.payment.service.PaymentService;
+import backend.global.dto.PageInfoDto;
 import backend.global.dto.SingleResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,13 +31,14 @@ public class PaymentController {
 
 
     @PatchMapping("/{paymentId}")
-    public ResponseEntity<SingleResDto<String>> patchPayment (@PathVariable Long paymentId,
+    public ResponseEntity<PayResDto> patchPayment (@PathVariable Long paymentId,
                                                          @RequestBody PayPatchReqDto payPatchReqDto) {
         Payment payment = payPatchReqDto.toPayment();
+        payment.setId(paymentId);
         Payment modifiedPayment = paymentService.patchPayment(payment);
         PayResDto response = new PayResDto(modifiedPayment);
 
-        return new ResponseEntity<>(new SingleResDto<>("success modify"), HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
@@ -44,7 +46,7 @@ public class PaymentController {
     public ResponseEntity<SingleResDto<String>> deletePayment (@PathVariable Long paymentId) {
         paymentService.deletePayment(paymentId);
 
-        return new ResponseEntity<>(new SingleResDto<>("success create"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
     }
 
 
@@ -56,10 +58,10 @@ public class PaymentController {
     }
 
     @GetMapping
-    public ResponseEntity<Page> getPayments (Pageable pageable) {
+    public ResponseEntity<PageInfoDto> getPayments (Pageable pageable) {
         Page<Payment> page = paymentService.getPayments(pageable);
 
-        return new ResponseEntity<>(page, HttpStatus.OK);
+        return new ResponseEntity<>(new PageInfoDto(page), HttpStatus.OK);
     }
 
 }

--- a/backend/src/main/java/backend/domain/payment/dto/PayPatchReqDto.java
+++ b/backend/src/main/java/backend/domain/payment/dto/PayPatchReqDto.java
@@ -19,7 +19,7 @@ public class PayPatchReqDto extends BaseTime {
                 .totalPrice(this.totalPrice)
                 .totalBatteries(this.totalBatteries)
                 .build();
-        setModifiedAt(LocalDateTime.now());
+        payment.setModifiedAt(LocalDateTime.now());
         return payment;
     }
 

--- a/backend/src/main/java/backend/domain/payment/dto/PayResDto.java
+++ b/backend/src/main/java/backend/domain/payment/dto/PayResDto.java
@@ -11,9 +11,7 @@ import java.time.LocalDateTime;
 public class PayResDto extends BaseTime {
 
     private Long paymentId;
-
     private int totalPrice;
-
     private int totalBatteries;
 
     public PayResDto(Payment payment) {

--- a/backend/src/main/java/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/backend/domain/payment/service/PaymentService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service @RequiredArgsConstructor @Transactional(readOnly = true)
@@ -29,8 +30,8 @@ public class PaymentService {
     public Payment patchPayment (Payment payment) {
         Payment savedPayment = paymentRepository.findById(payment.getId())
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND));
-        Optional.ofNullable(payment.getTotalPrice()).ifPresent(savedPayment::setTotalPrice);
-        Optional.ofNullable(payment.getTotalBatteries()).ifPresent(savedPayment::setTotalBatteries);
+        Optional.of(payment.getTotalPrice()).ifPresent(savedPayment::setTotalPrice);
+        Optional.of(payment.getTotalBatteries()).ifPresent(savedPayment::setTotalBatteries);
         savedPayment.setModifiedAt(payment.getModifiedAt());
 
         return paymentRepository.save(savedPayment);

--- a/backend/src/main/java/backend/domain/zone/controller/ZoneController.java
+++ b/backend/src/main/java/backend/domain/zone/controller/ZoneController.java
@@ -44,7 +44,7 @@ public class ZoneController {
     public ResponseEntity<SingleResDto<String>> deleteZone (@PathVariable Long zoneId) {
         zoneService.deleteZone(zoneId);
 
-        return new ResponseEntity<>(new SingleResDto<>("success delete"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
     }
 
 

--- a/backend/src/main/java/backend/domain/zone/entity/Zone.java
+++ b/backend/src/main/java/backend/domain/zone/entity/Zone.java
@@ -6,9 +6,6 @@ import lombok.*;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @AllArgsConstructor @NoArgsConstructor
 @Entity @Getter @Setter @Builder

--- a/backend/src/main/java/backend/domain/zone/service/ZoneService.java
+++ b/backend/src/main/java/backend/domain/zone/service/ZoneService.java
@@ -30,8 +30,8 @@ public class ZoneService {
 
         Optional.ofNullable(zone.getName()).ifPresent(savedZone::setName);
         Optional.ofNullable(zone.getDetails()).ifPresent(savedZone::setDetails);
-        Optional.ofNullable(zone.getLatitude()).ifPresent(savedZone::setLatitude);
-        Optional.ofNullable(zone.getLongitude()).ifPresent(savedZone::setLongitude);
+        Optional.of(zone.getLatitude()).ifPresent(savedZone::setLatitude);
+        Optional.of(zone.getLongitude()).ifPresent(savedZone::setLongitude);
 
         return zoneRepository.save(savedZone);
     }

--- a/backend/src/main/java/backend/global/exception/exceptionCode/ExceptionCode.java
+++ b/backend/src/main/java/backend/global/exception/exceptionCode/ExceptionCode.java
@@ -6,7 +6,7 @@ public enum ExceptionCode {
     // 비즈니스 모델에서 필요시 에러코드 추가하는 부분
 
     NOT_FOUND(404, "요청하신 데이터를 찾을 수 없습니다."),
-    NOT_FOUND_ACCOUNT(400, "계정을 찾을 수 없습니다."),
+    NOT_FOUND_MEMBER(400, "계정을 찾을 수 없습니다."),
 
     ACCOUNT_EXIST(400, "존재하는 계정입니다."),
 
@@ -17,7 +17,10 @@ public enum ExceptionCode {
     ILLEGAL_FILENAME(400, "잘못된 형식의 파일명입니다."),
     BATTERY_NOT_FOUND(400, "해당하는 ID의 배터리가 존재하지 않습니다."),
     ADMIN_NOT_FOUND(400, "해당하는 ID의 관리자가 존재하지 않습니다."),
-    ADMIN_EXIST(409, "해당 email의 관리자가 존재합니다.");
+    ADMIN_EXIST(409, "해당 email의 관리자가 존재합니다."),
+    EMAIL_EXIST(401, "중복된 email 입니다."),
+    NICKNAME_EXIST(401, "중복된 nickname 입니다.");
+
 
 
     @Getter


### PR DESCRIPTION
1. 기존 Member API를 Security기능을 빼고 사용하기 위해, Security 관련 코드를 주석처리 했습니다.

2. 일부 에러가 발생하는 코드를 리팩토링 했습니다.

3. 기존에 구현된 서비스 메소드에를 사용하기 위한 핸들러 메소드를 추가했습니다.

4. 쿼리 메소드의 쿼리문에 정렬조건을 추가했습니다. 

5. 회의에서 결정된 정책적인 이슈를 반영하여 계정 등록을 위한 verify 로직을 일부 수정했습니다.