### PR TITLE
[BE] Reservation과 Battery 연관관계 매핑, Station과의 순환참조 방지

### DIFF
--- a/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
+++ b/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
@@ -36,8 +36,8 @@ public class BatteryController {
     public ResponseEntity postBattery(@Valid @RequestBody BatteryDto.Post requestBody){
         Battery battery = mapper.batteryPostDtoToBattery(requestBody);
         Battery createBattery = batteryService.createBattery(battery);
-        BatteryDto.Response response = mapper.batteryToBatteryResponse(createBattery);
-
+//        BatteryDto.Response response = mapper.batteryToBatteryResponse(createBattery);
+        BatteryDto.Response response = new BatteryDto.Response(createBattery);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
@@ -57,14 +57,14 @@ public class BatteryController {
     @GetMapping("/{batteryId}")
     public ResponseEntity getBattery(@PathVariable("batteryId") @Positive long batteryId){
         Battery battery = batteryService.findBattery(batteryId);
-        BatteryDto.Response response = mapper.batteryToBatteryResponse(battery);
-
+//        BatteryDto.Response response = mapper.batteryToBatteryResponse(battery);
+        BatteryDto.Response response = new BatteryDto.Response(battery);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     // 배터리 전체 조회
     @GetMapping
-    public ResponseEntity getBatteries(Pageable pageable){
+    public ResponseEntity<PageInfoDto> getBatteries(Pageable pageable){
         Page<Battery> page = batteryService.findBatteries(pageable);
 
         return new ResponseEntity<>(new PageInfoDto<>(page), HttpStatus.OK);

--- a/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
+++ b/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
@@ -1,5 +1,7 @@
 package backend.domain.battery.dto;
 
+import backend.domain.battery.entity.Battery;
+import backend.domain.battery.entity.Reservation;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +11,8 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BatteryDto {
     @Getter
@@ -46,8 +50,44 @@ public class BatteryDto {
         private boolean status;
         private int price;
         private String photoURL;
-        private long zoneId;
+//        private long zoneId;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
+        private List<BatteryReservation> reservations;
+
+        public Response(Battery battery){
+            this.batteryId = battery.getBatteryId();
+            this.capacity = battery.getCapacity();
+            this.status = battery.isStatus();
+            this.price = battery.getPrice();
+            this.photoURL = battery.getPhotoURL();
+            this.createdAt = battery.getCreatedAt();
+            this.modifiedAt = battery.getModifiedAt();
+            this.reservations = BatteryReservation.batteryReservation(battery.getReservations());
+        }
+
+        @Getter
+        public static class BatteryReservation{
+            private Long reservationId;
+            private String startTime;
+            private String endTime;
+            private LocalDateTime reservationCreatedAt;
+            private LocalDateTime reservationModifiedAt;
+
+            public static List<BatteryReservation> batteryReservation(List<Reservation> reservations){
+                List<BatteryReservation> list = new ArrayList<>();
+                reservations.forEach(reservation -> {
+                    list.add(new BatteryReservation(reservation));
+                });
+                return list;
+            }
+            public BatteryReservation(Reservation reservation){
+                this.reservationId = reservation.getReservationId();
+                this.startTime = reservation.getStartTime();
+                this.endTime = reservation.getEndTime();
+                this.reservationCreatedAt = reservation.getCreatedAt();
+                this.reservationModifiedAt = reservation.getModifiedAt();
+            }
+        }
     }
 }

--- a/backend/src/main/java/backend/domain/battery/entity/Battery.java
+++ b/backend/src/main/java/backend/domain/battery/entity/Battery.java
@@ -1,7 +1,8 @@
 package backend.domain.battery.entity;
 
-import backend.domain.cart.entity.Cart;
-import backend.domain.zone.entity.Zone;
+import backend.domain.station.entity.Station;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,8 @@ import org.hibernate.validator.constraints.URL;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -34,12 +37,24 @@ public class Battery {
     private String photoURL;
 
     @ManyToOne
-    @JoinColumn(name = "zone_id")
-    private Zone zone;
+    @JoinColumn(name = "station_id")
+    @JsonBackReference
+    private Station station;
+
+    @OneToMany(mappedBy = "battery", cascade = CascadeType.ALL) // PERSIST인지 확인 필요
+    @JsonManagedReference
+    private List<Reservation> reservations = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(nullable = false, name = "LAST_MODIFIED_AT")
     private LocalDateTime modifiedAt = LocalDateTime.now();
+
+    public void addReservation(Reservation reservation){
+        this.reservations.add(reservation);
+        if(reservation.getBattery() != this){
+            reservation.setBattery(this);
+        }
+    }
 }

--- a/backend/src/main/java/backend/domain/battery/entity/Reservation.java
+++ b/backend/src/main/java/backend/domain/battery/entity/Reservation.java
@@ -1,0 +1,37 @@
+package backend.domain.battery.entity;
+
+import backend.global.auditing.BaseTime;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+public class Reservation extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reservationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "battery_id")
+    @JsonBackReference
+    private Battery battery;
+
+    @Column
+    private String startTime;
+
+    @Column
+    private String endTime;
+
+    public void addBattery(Battery battery){
+        this.battery = battery;
+        if(!this.battery.getReservations().contains(this)){
+            this.battery.getReservations().add(this);
+        }
+    }
+}

--- a/backend/src/main/java/backend/domain/battery/repository/ReservationRepository.java
+++ b/backend/src/main/java/backend/domain/battery/repository/ReservationRepository.java
@@ -1,0 +1,7 @@
+package backend.domain.battery.repository;
+
+import backend.domain.battery.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/backend/src/main/java/backend/domain/station/entity/Station.java
+++ b/backend/src/main/java/backend/domain/station/entity/Station.java
@@ -3,6 +3,7 @@ package backend.domain.station.entity;
 import backend.domain.battery.entity.Battery;
 import backend.domain.payment.entity.Payment;
 import backend.global.auditing.BaseTime;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
 import javax.persistence.*;
@@ -27,6 +28,7 @@ public class Station extends BaseTime {
     private String photoURL;
 
     @OneToMany(mappedBy = "station", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @JsonManagedReference
     private List<Battery> battery;
 
     @OneToMany(mappedBy = "station")

--- a/backend/src/main/resources/static/db/data.sql
+++ b/backend/src/main/resources/static/db/data.sql
@@ -1,6 +1,6 @@
 --더미 Member
 INSERT INTO Member(member_id,createdAt,modifiedAt,address,email,nickname,password,phone,photoURL) VALUES (1,'2022-11-19 17:32:55.325906','2022-11-19 17:32:55.325906','경기도 분당시 엄복동','test@gmail.com','테스트','123411aa','010-1111-2222','http://asd311114f6asd54f6aw');
-INSERT INTO Member(member_id,createdAt,modifiedAt,address,email,nickname,password,phone,photoURL) VALUES (2,'2022-11-19 17:33:04.000228','2022-11-19 17:33:04.000228','서울시 강남구 역삼동','nike@gmail.com','나이키','123411aa','010-1111-2222','http://asd311114f6asd54f6aw');
+INSERT INTO Member(member_id,createdAt,modifiedAt,address,email,nickname,password,phone,photoURL) VALUES (2,'2022-11-19 17:33:04.000228','2022-11-19 17:33:04.000228','서울시 강남구 역삼동','nike@gmail.com','나이키','123411aa','010-1111-2222','http://asd311114f6as3d54f6aw');
 
 --더미 Admin
 INSERT INTO Admin(adminId,createdAt,email,modifiedAt,password,phone) VALUES (1,'2022-11-19 17:33:16.026388','admin@gmail.com','2022-11-19 17:33:16.026388','asdf5t1234*','010-7942-7942');
@@ -22,7 +22,10 @@ INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,t
 INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (3,'2022-11-19 17:35:48.372801','2022-11-19 17:35:48.372801','끝나는 시간','카카오페이','시작 시간',0,50000,3,1,1);
 
 -- 더미 Reservation
-
+INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("1","1", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T09:52:37.9592711","2022-11-21T09:52:37.9592867");
+INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("2","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T09:52:37.9592711","2022-11-21T09:52:37.9592867");
+INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("3","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T09:52:37.9592711","2022-11-21T09:52:37.9592867");
+INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("4","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T09:52:37.9592711","2022-11-21T09:52:37.9592867");
 
 --더미 cart
 --insert into Cart(cart_id, startTime, endTime, member_id, zone_id, createdAt, modifiedAt) values('101', '2022-11-18T09', '2022-11-20T09','1001', '11', '2022-11-04T19:41:25.505236', '2022-11-15T19:41:25.505236');


### PR DESCRIPTION
## 구현내용
Battery와 Reservation의 엔티티 매핑을 완료하였습니다.
Battery와 Station 매핑에서의 순환참조를 방지하기 위해 각 엔티티에 @JsonBackReference와 @JsonManagedReference를 추가하였습니다.

## 전달할 내용
이전 PR에서 발견된 잘못된 패키지 경로를 수정하였습니다.(zone -> station)
Battery에서 Reservation을 조회할 때 station까지 조회가 되어 순환참조방지 어노테이션을 추가하였습니다.