### PR TITLE
[BE] Admin과 Station 연관관계 매핑, Mock 데이터 수정, BatteryName 칼럼 추가

### DIFF
--- a/backend/src/main/java/backend/domain/admin/controller/AdminController.java
+++ b/backend/src/main/java/backend/domain/admin/controller/AdminController.java
@@ -35,8 +35,8 @@ public class AdminController {
     public ResponseEntity postAdmin(@Valid @RequestBody AdminDto.Post requestBody){
         Admin admin = mapper.adminPostDtoToAdmin(requestBody);
         Admin createAdmin = adminService.createAdmin(admin);
-        AdminDto.Response response = mapper.adminToAdminResponse(createAdmin);
-
+//        AdminDto.Response response = mapper.adminToAdminResponse(createAdmin);
+        AdminDto.Response response = new AdminDto.Response(createAdmin);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
@@ -56,8 +56,8 @@ public class AdminController {
     @GetMapping("/{adminId}")
     public ResponseEntity getAdmin(@PathVariable("adminId") @Positive long adminId){
         Admin admin = adminService.findAdmin(adminId);
-        AdminDto.Response response = mapper.adminToAdminResponse(admin);
-
+//        AdminDto.Response response = mapper.adminToAdminResponse(admin);
+        AdminDto.Response response = new AdminDto.Response(admin);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -65,8 +65,9 @@ public class AdminController {
     @GetMapping
     public ResponseEntity<PageInfoDto> getAdmins (Pageable pageable){
         Page<Admin> page = adminService.findAdmins(pageable);
+        Page<AdminDto.Response> dtoPage = page.map(AdminDto.Response::new);
 
-        return new ResponseEntity<>(new PageInfoDto<>(page), HttpStatus.OK);
+        return new ResponseEntity<>(new PageInfoDto<>(dtoPage), HttpStatus.OK);
     }
 
     // 해당 ID 관리자 삭제

--- a/backend/src/main/java/backend/domain/admin/dto/AdminDto.java
+++ b/backend/src/main/java/backend/domain/admin/dto/AdminDto.java
@@ -1,5 +1,7 @@
 package backend.domain.admin.dto;
 
+import backend.domain.admin.entity.Admin;
+import backend.domain.station.entity.Station;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +10,8 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AdminDto {
     @Getter
@@ -49,5 +53,30 @@ public class AdminDto {
         private String phone;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
+        private List<Station> stationList;
+
+        public Response(Admin admin){
+            this.adminId = admin.getAdminId();
+            this.email = admin.getEmail();
+            this.password = admin.getPassword();
+            this.phone = admin.getPhone();
+            this.createdAt = admin.getCreatedAt();
+            this.modifiedAt = admin.getModifiedAt();
+
+            List<Station> list = new ArrayList<>();
+            for(int i = 0; i < admin.getStationList().size(); i++){
+                Station adminStation = new Station();
+                adminStation.setId(admin.getStationList().get(i).getId());
+                adminStation.setName(admin.getStationList().get(i).getName());
+                adminStation.setDetails(admin.getStationList().get(i).getDetails());
+                adminStation.setLatitude(admin.getStationList().get(i).getLatitude());
+                adminStation.setLongitude(admin.getStationList().get(i).getLongitude());
+                adminStation.setPhotoURL(admin.getStationList().get(i).getPhotoURL());
+                //배터리 추가해야함
+                adminStation.setBattery(admin.getStationList().get(i).getBattery());
+                list.add(adminStation);
+            }
+            this.stationList = list;
+        }
     }
 }

--- a/backend/src/main/java/backend/domain/admin/entity/Admin.java
+++ b/backend/src/main/java/backend/domain/admin/entity/Admin.java
@@ -1,11 +1,15 @@
 package backend.domain.admin.entity;
 
+import backend.domain.station.entity.Station;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -14,6 +18,7 @@ import java.time.LocalDateTime;
 public class Admin {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
     private Long adminId;
 
     @Column
@@ -30,4 +35,15 @@ public class Admin {
 
     @Column(nullable = false)
     private LocalDateTime modifiedAt = LocalDateTime.now();
+
+    @OneToMany(mappedBy = "admin", cascade = CascadeType.ALL)
+    @JsonManagedReference
+    private List<Station> stationList = new ArrayList<>();
+
+    public void addStation(Station station){
+        this.stationList.add(station);
+        if(station.getAdmin() != this){
+            station.setAdmin(this);
+        }
+    }
 }

--- a/backend/src/main/java/backend/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/backend/domain/admin/service/AdminService.java
@@ -44,7 +44,9 @@ public class AdminService {
 
     // 관리자 전체 조회
     public Page<Admin> findAdmins(Pageable pageable){
-        return adminRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Page<Admin> page = adminRepository.findAllByOrderByCreatedAtDesc(pageable);
+//        return adminRepository.findAllByOrderByCreatedAtDesc(pageable);
+        return page;
     }
 
     // 해당 ID 관리자 삭제

--- a/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
+++ b/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
@@ -30,8 +30,8 @@ public class BatteryDto {
         @URL
         private String photoURL;
 
-        @NotNull(message ="ZONE ID 를 입력해주세요.")
-        private long zoneId;
+//        @NotNull(message ="ZONE ID 를 입력해주세요.")
+//        private long zoneId;
     }
 
     @Getter
@@ -49,6 +49,7 @@ public class BatteryDto {
         private String capacity;
         private boolean status;
         private int price;
+        private String batteryName;
         private String photoURL;
 //        private long zoneId;
         private LocalDateTime createdAt;
@@ -60,6 +61,7 @@ public class BatteryDto {
             this.capacity = battery.getCapacity();
             this.status = battery.isStatus();
             this.price = battery.getPrice();
+            this.batteryName = battery.getBatteryName();
             this.photoURL = battery.getPhotoURL();
             this.createdAt = battery.getCreatedAt();
             this.modifiedAt = battery.getModifiedAt();

--- a/backend/src/main/java/backend/domain/battery/entity/Battery.java
+++ b/backend/src/main/java/backend/domain/battery/entity/Battery.java
@@ -32,6 +32,9 @@ public class Battery {
     @Column
     private int price;
 
+    @Column
+    private String batteryName;
+
     @URL
     @Column
     private String photoURL;

--- a/backend/src/main/java/backend/domain/battery/entity/StationBattery.java
+++ b/backend/src/main/java/backend/domain/battery/entity/StationBattery.java
@@ -17,6 +17,8 @@ public class StationBattery extends BaseTime {
 
     private int price;
 
+    private String batteryName;
+
     private String photoURL;
 
 }

--- a/backend/src/main/java/backend/domain/station/dto/StationResDto.java
+++ b/backend/src/main/java/backend/domain/station/dto/StationResDto.java
@@ -41,6 +41,7 @@ public class StationResDto {
             filteredbattery.setPhotoURL(station.getBattery().get(i).getPhotoURL());
             filteredbattery.setCreatedAt(station.getBattery().get(i).getCreatedAt());
             filteredbattery.setModifiedAt(station.getBattery().get(i).getModifiedAt());
+            filteredbattery.setBatteryName(station.getBattery().get(i).getBatteryName());
             list.add(filteredbattery);
         }
         this.batteries = list;

--- a/backend/src/main/java/backend/domain/station/entity/Station.java
+++ b/backend/src/main/java/backend/domain/station/entity/Station.java
@@ -1,8 +1,10 @@
 package backend.domain.station.entity;
 
+import backend.domain.admin.entity.Admin;
 import backend.domain.battery.entity.Battery;
 import backend.domain.payment.entity.Payment;
 import backend.global.auditing.BaseTime;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
@@ -36,4 +38,15 @@ public class Station extends BaseTime {
     @OneToMany(mappedBy = "station")
     private List<Payment> payment;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    @JsonBackReference
+    private Admin admin;
+
+    public void addAdmin(Admin admin){
+        this.admin = admin;
+        if(!this.admin.getStationList().contains(this)){
+            this.admin.getStationList().add(this);
+        }
+    }
 }

--- a/backend/src/main/resources/static/db/data.sql
+++ b/backend/src/main/resources/static/db/data.sql
@@ -3,19 +3,19 @@ INSERT INTO Member(member_id,createdAt,modifiedAt,address,email,nickname,passwor
 INSERT INTO Member(member_id,createdAt,modifiedAt,address,email,nickname,password,phone,photoURL) VALUES (2,'2022-11-19 17:33:04.000228','2022-11-19 17:33:04.000228','서울시 강남구 역삼동','nike@gmail.com','나이키','123411aa','010-1111-2222','http://asd311114f6as3d54f6aw');
 
 --더미 Admin
-INSERT INTO Admin(adminId,createdAt,email,modifiedAt,password,phone) VALUES (1,'2022-11-19 17:33:16.026388','admin@gmail.com','2022-11-19 17:33:16.026388','asdf5t1234*','010-7942-7942');
-INSERT INTO Admin(adminId,createdAt,email,modifiedAt,password,phone) VALUES (2,'2022-11-19 17:33:38.289305','admin2@gmail.com','2022-11-19 17:33:38.290304','asdf5t12342*','010-7942-7942');
+INSERT INTO Admin(admin_id,createdAt,email,modifiedAt,password,phone) VALUES (1,'2022-11-19 17:33:16.026388','admin@gmail.com','2022-11-19 17:33:16.026388','asdf5t1234*','010-7942-7942');
+INSERT INTO Admin(admin_id,createdAt,email,modifiedAt,password,phone) VALUES (2,'2022-11-19 17:33:38.289305','admin2@gmail.com','2022-11-19 17:33:38.290304','asdf5t12342*','010-7942-7942');
 
 -- 더미 Station
-INSERT INTO Station(station_id,createdAt,modifiedAt,details,latitude,longitude,name,photoURL,phone) VALUES (1,'2022-11-19 17:33:53.258093','2022-11-19 17:33:53.258093','첫번째 대여소',37.53737528,127.00557633,'인천제일주유소','@#!@DSAF!@#','010-1588-1588');
-INSERT INTO Station(station_id,createdAt,modifiedAt,details,latitude,longitude,name,photoURL,phone) VALUES (2,'2022-11-19 17:34:05.641588','2022-11-19 17:34:05.641588','두번째 대여소',37.545024,127.03923,'서울제일주유소','@#!@DSAF!@#','010-2580-2580');
+INSERT INTO Station(station_id, admin_id, createdAt,modifiedAt,details,latitude,longitude,name,photoURL,phone) VALUES (1,"1",'2022-11-19 17:33:53.258093','2022-11-19 17:33:53.258093','첫번째 대여소',37.53737528,127.00557633,'인천제일주유소','@#!@DSAF!@#','010-1588-1588');
+INSERT INTO Station(station_id, admin_id, createdAt,modifiedAt,details,latitude,longitude,name,photoURL,phone) VALUES (2,"2",'2022-11-19 17:34:05.641588','2022-11-19 17:34:05.641588','두번째 대여소',37.545024,127.03923,'서울제일주유소','@#!@DSAF!@#','010-2580-2580');
 
 --더미 Battery
-INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id) VALUES (1,'100000mA','2022-11-19 17:34:17.716045','2022-11-19 17:34:17.716045','http://asdfqwer111',50000,false,1);
-INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id) VALUES (2,'100000mA','2022-11-19 17:34:18.453315','2022-11-19 17:34:18.453315','http://asdfqwer111',50000,false,1);
-INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id) VALUES (3,'100000mA','2022-11-19 17:34:19.139197','2022-11-19 17:34:19.139197','http://asdfqwer111',50000,false,1);
-INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id) VALUES (4,'100000mA','2022-11-19 17:34:22.887204','2022-11-19 17:34:22.887204','http://asdfqwer111',50000,true,2);
-INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id) VALUES (5,'100000mA','2022-11-19 17:34:23.503853','2022-11-19 17:34:23.503853','http://asdfqwer111',50000,true,2);
+INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (1,'100000mA','2022-11-19 17:34:17.716045','2022-11-19 17:34:17.716045','http://asdfqwer111',50000,false,1,"Samsung");
+INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (2,'100000mA','2022-11-19 17:34:18.453315','2022-11-19 17:34:18.453315','http://asdfqwer111',50000,false,1,"Samsung");
+INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (3,'100000mA','2022-11-19 17:34:19.139197','2022-11-19 17:34:19.139197','http://asdfqwer111',50000,false,1,"Samsung");
+INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (4,'100000mA','2022-11-19 17:34:22.887204','2022-11-19 17:34:22.887204','http://asdfqwer111',50000,true,2,"Hyundai");
+INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (5,'100000mA','2022-11-19 17:34:23.503853','2022-11-19 17:34:23.503853','http://asdfqwer111',50000,true,2,"Hyundai");
 
 -- 더미 payment
 INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (1,'2022-11-19 17:34:32.536094','2022-11-19 17:34:32.537094','2022-11-20T23:30','카카오페이','2022-11-20T17:30',0,50000,1,1,1);


### PR DESCRIPTION
## 구현 내용
Admin과 Station 연관관계 매핑을 구현하였습니다.
Admins 조회 시 Battery와 Battery에 해당하는 reservation도 조회가 됩니다.
칼럼명 adminId _> admin_id 수정하였습니다.
회의 때 의논하였던 브랜드명 칼럼을 BatteryName으로 추가하였습니다.