### PR TITLE
[BE] Reservation과 Payment 연관관계 매핑

### DIFF
--- a/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
+++ b/backend/src/main/java/backend/domain/battery/controller/BatteryController.java
@@ -43,13 +43,9 @@ public class BatteryController {
 
     // 해당 ID 배터리 수정
     @PatchMapping("/{batteryId}")
-    public ResponseEntity patchBattery(@PathVariable("batteryId") @Positive long batteryId,
-                                       @Valid @RequestBody BatteryDto.Patch requestBody){
-        requestBody.setBatteryId(batteryId);
-        Battery battery = mapper.batteryPatchDtoToBattery(requestBody);
-        Battery updateBattery = batteryService.updateBattery(battery);
-        BatteryDto.Response response = mapper.batteryToBatteryResponse(updateBattery);
-
+    public ResponseEntity patchBattery(@PathVariable("batteryId") @Positive long batteryId){
+        Battery updateBattery = batteryService.updateBattery(batteryId);
+        BatteryDto.Response response = new BatteryDto.Response(updateBattery);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
+++ b/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
@@ -2,6 +2,8 @@ package backend.domain.battery.dto;
 
 import backend.domain.battery.entity.Battery;
 import backend.domain.battery.entity.Reservation;
+import backend.domain.payment.entity.PayStatus;
+import backend.domain.station.entity.Station;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -75,6 +77,8 @@ public class BatteryDto {
             private String endTime;
             private LocalDateTime reservationCreatedAt;
             private LocalDateTime reservationModifiedAt;
+            private PayStatus payStatus;
+            private Long stationId;
 
             public static List<BatteryReservation> batteryReservation(List<Reservation> reservations){
                 List<BatteryReservation> list = new ArrayList<>();
@@ -89,6 +93,8 @@ public class BatteryDto {
                 this.endTime = reservation.getEndTime();
                 this.reservationCreatedAt = reservation.getCreatedAt();
                 this.reservationModifiedAt = reservation.getModifiedAt();
+                this.payStatus = reservation.getPayStatus();
+                this.stationId = reservation.getStationId();
             }
         }
     }

--- a/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
+++ b/backend/src/main/java/backend/domain/battery/dto/BatteryDto.java
@@ -31,9 +31,6 @@ public class BatteryDto {
 
         @URL
         private String photoURL;
-
-//        @NotNull(message ="ZONE ID 를 입력해주세요.")
-//        private long zoneId;
     }
 
     @Getter
@@ -53,7 +50,6 @@ public class BatteryDto {
         private int price;
         private String batteryName;
         private String photoURL;
-//        private long zoneId;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
         private List<BatteryReservation> reservations;

--- a/backend/src/main/java/backend/domain/battery/entity/Reservation.java
+++ b/backend/src/main/java/backend/domain/battery/entity/Reservation.java
@@ -1,5 +1,7 @@
 package backend.domain.battery.entity;
 
+import backend.domain.payment.entity.PayStatus;
+import backend.domain.payment.entity.Payment;
 import backend.global.auditing.BaseTime;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
@@ -28,10 +30,28 @@ public class Reservation extends BaseTime {
     @Column
     private String endTime;
 
+    @Column
+    private PayStatus payStatus;
+
+    @Column
+    private Long stationId;
+
+    @ManyToOne(fetch =FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    @JsonBackReference
+    private Payment payment;
+
     public void addBattery(Battery battery){
         this.battery = battery;
         if(!this.battery.getReservations().contains(this)){
             this.battery.getReservations().add(this);
         }
     }
+
+//    public void addPayment(Payment payment){
+//        this.payment = payment;
+//        if(!this.payment.getReservations().contains(this)){
+//            this.payment.getReservations().add(this);
+//        }
+//    }
 }

--- a/backend/src/main/java/backend/domain/battery/service/BatteryService.java
+++ b/backend/src/main/java/backend/domain/battery/service/BatteryService.java
@@ -25,9 +25,13 @@ public class BatteryService {
     }
 
     // 배터리 수정
-    public Battery updateBattery(Battery battery){
-        Battery findBattery = findVerifiedBattery(battery.getBatteryId());
-        findBattery.setStatus(battery.isStatus());
+    public Battery updateBattery(long batteryId){
+        Battery findBattery = findVerifiedBattery(batteryId);
+        if(!findBattery.isStatus()){
+            findBattery.setStatus(true);
+        }else{
+            findBattery.setStatus(false);
+        }
         findBattery.setModifiedAt(LocalDateTime.now());
 
         return batteryRepository.save(findBattery);

--- a/backend/src/main/java/backend/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/backend/domain/payment/entity/Payment.java
@@ -1,19 +1,23 @@
 package backend.domain.payment.entity;
 
 import backend.domain.battery.entity.Battery;
+import backend.domain.battery.entity.Reservation;
 import backend.domain.member.entity.Member;
 import backend.domain.station.entity.Station;
 import backend.global.auditing.BaseTime;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.List;
 
 @NoArgsConstructor @AllArgsConstructor
 @Entity @Getter @Setter @Builder
 public class Payment extends BaseTime {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
     private Long id;
 
     private int totalPrice;
@@ -41,7 +45,8 @@ public class Payment extends BaseTime {
     @JsonBackReference
     private Member member;
 
-//    @OneToMany(mappedBy = "payment", cascade = CascadeType.REMOVE)  // 예약 테이블과 연관관계 매핑
-//    private List<reservation> reservation;
+    @OneToMany(mappedBy = "payment", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private List<Reservation> reservations;
 
 }

--- a/backend/src/main/java/backend/domain/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/backend/domain/payment/repository/PaymentRepository.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    @EntityGraph(attributePaths = {"battery"})
+    @EntityGraph(attributePaths = {"battery","station","reservation"})
     Page<Payment> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
 }

--- a/backend/src/main/java/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/backend/domain/payment/service/PaymentService.java
@@ -1,7 +1,9 @@
 package backend.domain.payment.service;
 
 import backend.domain.battery.entity.Battery;
+import backend.domain.battery.entity.Reservation;
 import backend.domain.battery.repository.BatteryRepository;
+import backend.domain.battery.repository.ReservationRepository;
 import backend.domain.member.entity.Member;
 import backend.domain.member.repository.MemberRepository;
 import backend.domain.payment.entity.Payment;
@@ -28,6 +30,8 @@ public class PaymentService {
     private final StationRepository stationRepository;
 
     private final MemberRepository memberRepository;
+
+    private final ReservationRepository reservationRepository;
 
     @Transactional
     public Payment postPayment (Payment payment, Long batteryId, Long memberId) {
@@ -63,6 +67,18 @@ public class PaymentService {
         Optional.ofNullable(payment.getStatus()).ifPresent(savedPayment::setStatus);
         Optional.of(payment.getPayMethod()).ifPresent(savedPayment::setPayMethod);
         savedPayment.setModifiedAt(payment.getModifiedAt());
+        Reservation reservation = new Reservation();
+        if(savedPayment.getStatus().getCode() == 1){
+            reservation.setStartTime(savedPayment.getStartTime());
+            reservation.setEndTime(savedPayment.getEndTime());
+            reservation.setPayment(savedPayment);
+            reservation.setBattery(savedPayment.getBattery());
+            reservation.setStationId(savedPayment.getStation().getId());
+            reservation.setCreatedAt(savedPayment.getCreatedAt());
+            reservation.setModifiedAt(savedPayment.getModifiedAt());
+            reservation.setPayStatus(savedPayment.getStatus());
+            reservationRepository.save(reservation);
+        }
 
         return paymentRepository.save(savedPayment);
     }

--- a/backend/src/main/resources/static/db/data.sql
+++ b/backend/src/main/resources/static/db/data.sql
@@ -18,19 +18,19 @@ INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price
 INSERT INTO Battery(batteryId,capacity,createdAt,LAST_MODIFIED_AT,photoURL,price,status,station_id, batteryName) VALUES (5,'100000mA','2022-11-19 17:34:23.503853','2022-11-19 17:34:23.503853','http://asdfqwer111',50000,true,2,"Hyundai");
 
 -- 더미 payment
-INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (1,'2022-11-19 17:34:32.536094','2022-11-19 17:34:32.537094','2022-11-20T23:30','카카오페이','2022-11-20T17:30',0,50000,1,1,1);
-INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (2,'2022-11-19 17:35:42.896863','2022-11-19 17:35:42.896863','2022-11-21T19:00','카카오페이','2022-11-21T09:00',0,50000,2,1,1);
-INSERT INTO Payment(id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (3,'2022-11-19 17:35:48.372801','2022-11-19 17:35:48.372801','2022-11-25T09:00','카카오페이','2022-11-23T09:00',0,50000,3,1,1);
+INSERT INTO Payment(payment_id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (1,'2022-11-19 17:34:32.536094','2022-11-19 17:34:32.537094','2022-11-20T23:30','카카오페이','2022-11-20T17:30',0,50000,1,1,1);
+INSERT INTO Payment(payment_id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (2,'2022-11-19 17:35:42.896863','2022-11-19 17:35:42.896863','2022-11-21T19:00','카카오페이','2022-11-21T09:00',0,50000,2,1,1);
+INSERT INTO Payment(payment_id,createdAt,modifiedAt,endTime,payMethod,startTime,status,totalPrice,battery_id,member_id,station_id) VALUES (3,'2022-11-19 17:35:48.372801','2022-11-19 17:35:48.372801','2022-11-25T09:00','카카오페이','2022-11-23T09:00',1,50000,3,1,2);
 
 -- 더미 Reservation
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("1","1", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("11","1", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("2","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("22","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("3","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T16:30","2022-11-20T23:30");  --안됨
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("4","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-19T16:30","2022-11-19T23:30");  --됨 before
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("5","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T18:30","2022-11-20T22:30");  --안됨
-INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("55","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T18:30","2022-11-20T22:30");  --안됨
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("1","1", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("11","1", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("2","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("22","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-21T13:30","2022-11-21T23:30");  --됨 after
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("3","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T16:30","2022-11-20T23:30");  --안됨
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("4","3", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-19T16:30","2022-11-19T23:30");  --됨 before
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("5","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T18:30","2022-11-20T22:30");  --안됨
+--INSERT INTO Reservation(reservationId, battery_id, createdAt, modifiedAt, startTime, endTime) VALUES ("55","2", "2022-11-15T09:52:37.9592711","2022-11-15T09:52:37.9592867", "2022-11-20T18:30","2022-11-20T22:30");  --안됨
 -- avail = 1, 2, 3
 -- unavail = 3, 2
 -- final = 1


### PR DESCRIPTION
## 구현 내용
Reservation과 Payment  N:1 연관관계 매핑을 하였습니다.
PatchPayment를 진행하여 결제완료가 되었을 경우 payment 내역 중 일부가 reservation으로 생성됩니다.
Mock data 중 Payment의 수정이 있습니다. (id -> payment_id)

## 전달 내용
data.sql Mock 데이터 중 Reservation은 주석 처리를 하였습니다.
혹시 reservation이 필요하시다면, payment의 Mock 데이터들을 (payment_id 1,2,3) 
PatchPayment 진행해주시면 해당하는 payment가 reservation으로 생성이 됩니다.
참고로 payStatus의 결제완료 값은 1입니다.

![image](https://user-images.githubusercontent.com/73528227/203713961-8e096f26-df47-4f1a-bc97-610e7ca03045.png)


