### PR TITLE
[BE] 로그인 한 Member의 JWT로부터 claims 정보 추출 유틸 구현

### DIFF
--- a/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
@@ -29,10 +29,7 @@ import java.util.Map;
 public class PaymentController {
 
     private final PaymentService paymentService;
-
     private final JwtExtractUtils jwtExtractUtils;
-
-    private final JwtTokenizer jwtTokenizer;
 
     @PostMapping
     public ResponseEntity<PayResDto> postPayment(HttpServletRequest request,

--- a/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/backend/domain/payment/controller/PaymentController.java
@@ -8,6 +8,8 @@ import backend.domain.payment.entity.Payment;
 import backend.domain.payment.service.PaymentService;
 import backend.global.dto.PageInfoDto;
 import backend.global.dto.SingleResDto;
+import backend.global.security.jwt.JwtTokenizer;
+import backend.global.security.utils.JwtExtractUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,17 +18,27 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.Map;
 
-@RequiredArgsConstructor @Validated
-@RestController @RequestMapping("/payments")
+@RequiredArgsConstructor
+@Validated
+@RestController
+@RequestMapping("/payments")
 public class PaymentController {
 
     private final PaymentService paymentService;
 
+    private final JwtExtractUtils jwtExtractUtils;
+
+    private final JwtTokenizer jwtTokenizer;
+
     @PostMapping
-    public ResponseEntity<PayResDto> postPayment (@RequestParam Long memberId,
-                                                  @Valid @RequestBody PayPostReqDto payPostReqDto) {
+    public ResponseEntity<PayResDto> postPayment(HttpServletRequest request,
+                                                 @Valid @RequestBody PayPostReqDto payPostReqDto) {
+
+        Long memberId = jwtExtractUtils.extractMemberIdFromJwt(request);
         Payment payment = payPostReqDto.toPayment();
         Payment savedPayment = paymentService.postPayment(payment, payPostReqDto.getBatteryId(), memberId);
         PayResDto response = new PayResDto(savedPayment);
@@ -36,8 +48,8 @@ public class PaymentController {
 
 
     @PatchMapping("/{paymentId}")
-    public ResponseEntity<PayResDto> patchPayment (@PathVariable Long paymentId,
-                                                         @RequestBody PayPatchReqDto payPatchReqDto) {
+    public ResponseEntity<PayResDto> patchPayment(@PathVariable Long paymentId,
+                                                  @RequestBody PayPatchReqDto payPatchReqDto) {
         Payment payment = payPatchReqDto.toPayment();
         payment.setId(paymentId);
         Payment modifiedPayment = paymentService.patchPayment(payment);
@@ -48,7 +60,7 @@ public class PaymentController {
 
 
     @DeleteMapping("/{paymentId}")
-    public ResponseEntity<SingleResDto<String>> deletePayment (@PathVariable Long paymentId) {
+    public ResponseEntity<SingleResDto<String>> deletePayment(@PathVariable Long paymentId) {
         paymentService.deletePayment(paymentId);
 
         return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
@@ -56,14 +68,14 @@ public class PaymentController {
 
 
     @GetMapping("/{paymentId}")
-    public ResponseEntity<PayBillsResDto> getPayment (@PathVariable Long paymentId) {
+    public ResponseEntity<PayBillsResDto> getPayment(@PathVariable Long paymentId) {
         Payment payment = paymentService.getPayment(paymentId);
 
         return new ResponseEntity<>(new PayBillsResDto(payment), HttpStatus.OK);
     }
 
     @GetMapping
-    public ResponseEntity<PageInfoDto> getPayments (Pageable pageable) {
+    public ResponseEntity<PageInfoDto> getPayments(Pageable pageable) {
         Page<Payment> page = paymentService.getPayments(pageable);
         Page<PayResDto> dtoPage = page.map(PayResDto::new);
 

--- a/backend/src/main/java/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/backend/domain/payment/service/PaymentService.java
@@ -35,7 +35,7 @@ public class PaymentService {
 
     @Transactional
     public Payment postPayment (Payment payment, Long batteryId, Long memberId) {
-        Member member =memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)); // 로그인 한 계정이 존재하는지 확인
 
         Battery battery = batteryRepository.findById(batteryId)

--- a/backend/src/main/java/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -63,7 +63,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = delegateAccessToken(authenticatedMember);
         String refreshToken = delegateRefreshToken(authenticatedMember);
 
-        response.setHeader("AccessToken", "bearer"+accessToken);
+        response.setHeader("AccessToken", "Bearer " + accessToken);
         response.setHeader("RefreshToken", refreshToken);
 
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);  // 추가
@@ -80,9 +80,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private String delegateAccessToken(Member member) {
 
         Map<String, Object> claims = new HashMap<>();
+        // 여기서 뽑아오기 확인하기
         claims.put("email", member.getEmail());
         claims.put("memberId", member.getId());
-        claims.put("password", member.getPassword());
         String subject = member.getEmail();
 //        String subject = member.getNickname();
         Date accessTokenExpDate = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());

--- a/backend/src/main/java/backend/global/security/utils/JwtExtractUtils.java
+++ b/backend/src/main/java/backend/global/security/utils/JwtExtractUtils.java
@@ -1,0 +1,35 @@
+package backend.global.security.utils;
+
+import backend.global.security.jwt.JwtTokenizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+@RequiredArgsConstructor @Component
+public class JwtExtractUtils {
+
+    private final JwtTokenizer jwtTokenizer;
+
+    public Long extractMemberIdFromJwt (HttpServletRequest request) {
+        String jws = request.getHeader("Authorization").replace("Bearer ", "");
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        Map<String, Object> claims = jwtTokenizer.getJwsClaims(jws, base64EncodedSecretKey).getBody();
+        Object value = claims.get("memberId");
+        Long memberId = Long.valueOf(String.valueOf(value));
+
+        return memberId;
+    }
+
+    public String extractEmailFromJwt (HttpServletRequest request) {
+        String jws = request.getHeader("Authorization").replace("Bearer ", "");
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        Map<String, Object> claims = jwtTokenizer.getJwsClaims(jws, base64EncodedSecretKey).getBody();
+        Object value = claims.get("email");
+        String email = String.valueOf(String.valueOf(value));
+
+        return email;
+    }
+
+}


### PR DESCRIPTION
로그인시 발행되는 JWT가 API Request로 들어올 때,
JWT내 claims에 있는 email과 memberId값을 추출하는 Util을 구현했습니다.

사용법은 아래와 같이 적용해주시면 됩니다.
* 현재 시범 API로 postPayment에 로그인 검증 로직을 구현해두었습니다. 참고 하시면 좋습니다. 
* 테스트 방법은 회원가입 -> 로그인 -> postPayment 요청 하시면 됩니다.
(로그인 시 발급받은 JWT복사 -> Postman 요청시 Authorization 탭 내 Bearer Token선택 -> 복사한 JWT 붙여넣기를 하셔야 정상적으로 Payment요청이 이루어 지며, 토큰을 안보내시면 NullPointException이 발생합니다.)

![image](https://user-images.githubusercontent.com/94734089/203747606-0020cc23-14ff-415e-895b-5d2a50622cef.png)



