### PR TITLE
[BE] KakaoPay 결제취소, payMethod 저장 구현

### DIFF
--- a/backend/src/main/java/backend/domain/kakaoPay/KakaoPayCancelVO.java
+++ b/backend/src/main/java/backend/domain/kakaoPay/KakaoPayCancelVO.java
@@ -1,0 +1,16 @@
+package backend.domain.kakaoPay;
+
+import lombok.Data;
+
+import java.util.Date;
+@Data
+public class KakaoPayCancelVO {
+    //response
+    private String aid, tid, cid, sid;
+    private String partner_order_id, partner_user_id, payment_method_type;
+    private AmountVO amount;
+    private CardVO card_info;
+    private String item_name, item_code, payload;
+    private Integer quantity, tax_free_amount, vat_amount;
+    private Date created_at, approved_at;
+}

--- a/backend/src/main/java/backend/domain/kakaoPay/KakaoPayController.java
+++ b/backend/src/main/java/backend/domain/kakaoPay/KakaoPayController.java
@@ -50,9 +50,10 @@ public class KakaoPayController {
     }
 
     // 결제 취소시 실행 url
-    @GetMapping("/kakaoPayCancel")
-    public String payCancel() {
-        return "redirect:/carts";
+    @PostMapping("/kakaoPayCancel")
+    public void kakaoPayCancel(@RequestParam(name = "paymentId") Long paymentId,
+                               @RequestParam(name = "cancel_amount") int cancel_amount,Model model) {
+        model.addAttribute("info", kakaopay.kakaoPayCancel(paymentId, cancel_amount));
     }
 
     // 결제 실패시 실행 url

--- a/backend/src/main/java/backend/domain/kakaoPay/KakaoPayService.java
+++ b/backend/src/main/java/backend/domain/kakaoPay/KakaoPayService.java
@@ -117,6 +117,7 @@ public class KakaoPayService {
 //            try{
             payment.setStatus(PayStatus.WAITING_FOR_RESERVATION);
             payment.setTid(kakaoPayReadyVO.getTid());
+            payment.setPayMethod(kakaoPayApprovalVO.getCard_info().getPurchase_corp());
             paymentService.patchPayment(payment);
 
             return kakaoPayApprovalVO;

--- a/backend/src/main/java/backend/domain/kakaoPay/KakaoPayService.java
+++ b/backend/src/main/java/backend/domain/kakaoPay/KakaoPayService.java
@@ -1,9 +1,12 @@
 package backend.domain.kakaoPay;
 
+import backend.domain.battery.repository.ReservationRepository;
 import backend.domain.payment.entity.PayStatus;
 import backend.domain.payment.entity.Payment;
 import backend.domain.payment.repository.PaymentRepository;
 import backend.domain.payment.service.PaymentService;
+import backend.global.exception.dto.BusinessLogicException;
+import backend.global.exception.exceptionCode.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.http.HttpEntity;
@@ -26,6 +29,7 @@ public class KakaoPayService {
     private static final String HOST = "https://kapi.kakao.com";
     private final PaymentRepository paymentRepository;
     private final PaymentService paymentService;
+    private final ReservationRepository reservationRepository;
     private KakaoPayReadyVO kakaoPayReadyVO;
     private KakaoPayApprovalVO kakaoPayApprovalVO;
     private String itemName;
@@ -121,6 +125,49 @@ public class KakaoPayService {
 //                payment.setStatus(PayStatus.FAIL);
 //                paymentRepository.save(payment);
 //            }
+
+        } catch (RestClientException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (URISyntaxException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public KakaoPayCancelVO kakaoPayCancel(Long paymentId, int cancel_amount){
+        RestTemplate restTemplate = new RestTemplate();
+        KakaoPayCancelVO kakaoPayCancelVO;
+        Payment savedPayment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PAY_NOT_FOUND));
+        String tid = savedPayment.getTid();
+
+        // 서버로 요청할 Header
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "KakaoAK " + "82d314b8fd7c2c1f79dadd248f79a7b0");
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
+
+        // 서버로 요청할 Body
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<String, String>();
+        params.add("cid", "TC0ONETIME");
+        params.add("tid", tid);// 결제고유 번호
+        params.add("cancel_amount", String.valueOf(cancel_amount));//취소 상품 총 금액
+        params.add("cancel_tax_free_amount", "100");
+
+        HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<MultiValueMap<String, String>>(params, headers);
+        try {
+            kakaoPayCancelVO = restTemplate.postForObject(new URI(HOST + "/v1/payment/cancel"), body, KakaoPayCancelVO.class);
+
+            log.info("" + kakaoPayCancelVO);
+
+            savedPayment.setStatus(PayStatus.CANCELED);
+            paymentRepository.save(savedPayment);
+            reservationRepository.deleteById(savedPayment.getReservations().get(0).getReservationId());
+
+            return kakaoPayCancelVO;
 
         } catch (RestClientException e) {
             // TODO Auto-generated catch block

--- a/backend/src/main/java/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/backend/domain/member/dto/MemberDto.java
@@ -22,10 +22,12 @@ public class MemberDto {
         @NotBlank @Email
         private String email;
 
-        @NotBlank @Pattern(regexp = "^[가-힣a-zA-Z]*$")
+        @NotBlank @Pattern(regexp = "^(?=.[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$",
+        message = "영어 소문자, 한글, 숫자로 2자 이상 16자 이하까지 작성해주세요.")
         private String nickname;
 
-        @NotBlank
+        @NotBlank @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+                message = "비밀번호는 영문과 숫자, 특수기호를 적어도 1개 이상씩 포함하여 8자 ~ 20자여야 합니다.")
         private String password;
 
         @NotBlank
@@ -45,7 +47,8 @@ public class MemberDto {
     public static class Patch {
 
         //정규식 필요
-        @NotBlank @Pattern(regexp = "^[가-힣a-zA-Z]*$")
+        @NotBlank @Pattern(regexp = "^(?=.[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$",
+                message = "영어 소문자, 한글, 숫자로 2자 이상 16자 이하까지 작성해주세요.")
         private String nickname;
 
         @NotBlank
@@ -103,6 +106,8 @@ public class MemberDto {
     public static class PostResDto{
         private Long memberId;
         private String email;
+        @NotBlank @Pattern(regexp = "^(?=.[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$",
+                message = "영어 소문자, 한글, 숫자로 2자 이상 16자 이하까지 작성해주세요.")
         private String nickname;
 
         public PostResDto(Member member) {


### PR DESCRIPTION
## 구현 내용
KakaoPay의 결제취소 기능을 구현하였습니다.
파리미터로 paymentId와 cancel_amount 값을 /kakaoPayCancel로 POST요청을 하면 됩니다.
KakaoPay 결제취소가 완료되면 해당 Payment의 payStatus 상태값은 'CANCEL'이 되며, 해당 reservation은 삭제가 됩니다.
KakaoPay 결제완료 시 결제카드사 이름이 해당 payment의 payMethod로 저장되도록 구현하였습니다.